### PR TITLE
Update modbus-tcp-ip.html

### DIFF
--- a/modbus-tcp-ip.html
+++ b/modbus-tcp-ip.html
@@ -4,7 +4,7 @@
         color: '#D8BFD8',
         defaults: {
             name: {value:"modbus get"},
-            ip: {value:"192.168.0.100", type:"string"},
+            ip: {value:"192.168.0.100"},
             port: {value:502, type:"number"},
             timeout: {value:100, type:"number"},
             retries: {value:0, type:"number"},


### PR DESCRIPTION
remove type definition for string since this leads to error messages in node configuration